### PR TITLE
Add filter for flow event types to the es query.

### DIFF
--- a/flare/analytics/command_control.py
+++ b/flare/analytics/command_control.py
@@ -177,7 +177,7 @@ class elasticBeacon(object):
                             "analyze_wildcard": 'true'
                         }
                     },
-                    "filter": {
+                    "filter": [ {
                         "bool": {
                             "must": [
                                 {
@@ -192,7 +192,9 @@ class elasticBeacon(object):
                             ],
                             "must_not": []
                         }
-                    }
+                    },
+                        { "term": { "event_type": "flow" } }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
This prevents errors when using the base logstash-* index which may contain other events. Allows flare to work with a standard ELK install in addition to SELKS/KTS5.