### PR TITLE
Fixed scripts to be python3 print compatible and an import bug 

### DIFF
--- a/bin/hextoip
+++ b/bin/hextoip
@@ -15,7 +15,7 @@ def main():
 
     query_i = args.hex_value
 
-    print hex_to_ip(query_i)
+    print(hex_to_ip(query_i))
 
 
 if __name__ == '__main__':

--- a/bin/iptohex
+++ b/bin/iptohex
@@ -2,7 +2,7 @@
 
 import argparse
 
-from flare.utils.iputils import ip_to_hex
+from flare.tools.iputils import ip_to_hex
 
 
 def main():

--- a/bin/iptohex
+++ b/bin/iptohex
@@ -15,7 +15,7 @@ def main():
 
     query_i = args.ipv4_value
 
-    print ip_to_hex(query_i)
+    print(ip_to_hex(query_i))
 
 
 if __name__ == '__main__':

--- a/bin/ipwhois
+++ b/bin/ipwhois
@@ -17,7 +17,7 @@ def main():
     raw_results = json.dumps(whoisip.WhoisLookup().get_name_by_ip(
         query_ip), sort_keys=True, indent=4)
 
-    print raw_results
+    print(raw_results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changed `print` to using `print()` 

Also fixed import in the `iptohex` script from `flare.utils.iputils` to `flare.tools.iputils`