### PR TITLE
Adding __contains__ to domain tools

### DIFF
--- a/flare/tools/alexa.py
+++ b/flare/tools/alexa.py
@@ -25,11 +25,15 @@ class Alexa(object):
     def subdomain_in_alexa(self, word):
         return word in self.SUBDOMAINS_TOP1M
 
+    def __contains__(self, word):
+        return self.domain_in_alexa(word)
+
 
 # EXAMPLES
 
 #alexa = Alexa(limit=100)
 #print alexa.domain_in_alexa('google.com')
+#print 'google.com' in alexa
 #print alexa.subdomain_in_alexa('com')
 
 #print alexa.DOMAINS_TOP1M

--- a/flare/tools/majestic.py
+++ b/flare/tools/majestic.py
@@ -40,6 +40,9 @@ class majesticMillion(object):
     def domain_in_majestic(self, domain):
         return domain in self.MAJESTIC_DOMAINS
 
+    def __contains__(self, domain):
+        return self.domain_in_majestic(domain)
+
 
 
 

--- a/flare/tools/umbrella.py
+++ b/flare/tools/umbrella.py
@@ -52,3 +52,6 @@ class Umbrella(object):
             return True
 
         return False
+
+    def __contains__(self, word):
+        return self.domain_tld_in_umbrella(word)


### PR DESCRIPTION
Adding `__contains__` to `Umbrella`, `Alexa` and `majesticMillion` to have more pythonic and consistent way of looking up a `domain_tld`.

```python
from flare.tools.alexa import Alexa
from flare.tools.majestic import majesticMillion
from flare.tools.umbrella import Umbrella

alexa = Alexa()
umbrella = Umbrella()
majestic = majesticMillion()

'google.com' in alexa 
# True
'google.com' in majestic
# True
'google.com' in umbrella
# True
```