### PR TITLE
Adding umbrella top 1M domains to data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,10 @@ setup(
             'flare/data/tld/tld_list.pkl']),
         ('flare/data/misc', [
             'flare/data/misc/dga_domains.txt',
-            'flare/data/misc/words.txt'])],
+            'flare/data/misc/words.txt']),
+        ('flare/data/umbrella', [
+            'flare/data/umbrella/top-1m.csv']),
+    ],
      extras_require={
         ':python_version == "2.7"': [
             'ipaddr==2.1.11',


### PR DESCRIPTION
This is to make the library consistent in terms of the data it has. Currently `Alexa`, and `majesticMillion` both have the top domains in data. 

Although it should also be considered that adding too much data in the repository can make the library bulky.