### PR TITLE
Fix config debug

### DIFF
--- a/flare/analytics/command_control.py
+++ b/flare/analytics/command_control.py
@@ -102,7 +102,7 @@ class elasticBeacon(object):
                 try:
                     self.debug = self.config.config.getboolean('beacon', 'debug')
                 except:
-                    pass
+                    self.debug = debug
 
 
             except Exception as e:
@@ -132,6 +132,7 @@ class elasticBeacon(object):
             self.filter = ''
             self.verbose = verbose
             self.suricata_defaults = False
+            self.debug = debug
 
         self.ver = {'4': {'filtered': 'query'}, '5': {'bool': 'must'}}
         self.filt = list(self.ver[self.kibana_version].keys())[0]


### PR DESCRIPTION
When running with config, the script flare_beacon returns this error:

ERROR: 'elasticBeacon' object has no attribute 'debug'

By setting a default value, this can be avoided
